### PR TITLE
Added options and removed warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,9 @@ Very simple Swift wrapper of [cmark](https://github.com/jgm/cmark). Uses a [fork
 
 ```swift
 let markdown = "# Hello"
-let html = try markdownToHTML(markdown)
+let html = try markdownToHTML(markdown, options: [])
 print(html) //"<h1>Hello</h1>\n"
 ```
-
-# Warning
-Due to a bug in SwiftPM Xcode generation [SR-2526](https://bugs.swift.org/browse/SR-2526), if you're using this package in Xcode, you'll need to add one more header search path to the ccmark target: `Packages/cmark-0.26.1/Sources/ccmark/include`. After you do, everything should build fine in Xcode.
 
 # Installation
 

--- a/Sources/cmark.swift/cmark_swift.swift
+++ b/Sources/cmark.swift/cmark_swift.swift
@@ -1,22 +1,37 @@
 import ccmark
 
 public enum MarkdownError: Error {
-    case conversionFailed
+	case conversionFailed
 }
 
-public func markdownToHTML(_ str: String) throws -> String {
+public struct MarkdownOptions: OptionSet {
+	public let rawValue: Int32
+	
+	public init(rawValue: Int32) {
+		self.rawValue = rawValue
+	}
+	
+	static public let sourcePosition = MarkdownOptions(rawValue: 1 << 1)
+	static public let hardBreaks = MarkdownOptions(rawValue: 1 << 2)
+	static public let safe = MarkdownOptions(rawValue: 1 << 3)
+	static public let noBreaks = MarkdownOptions(rawValue: 1 << 4)
+	static public let normalize = MarkdownOptions(rawValue: 1 << 8)
+	static public let validateUTF8 = MarkdownOptions(rawValue: 1 << 9)
+	static public let smartQuotes = MarkdownOptions(rawValue: 1 << 10)
+}
+
+public func markdownToHTML(_ str: String, options: MarkdownOptions = []) throws -> String {
 	var buffer: String?
-    try str.withCString {
-        //TODO: add options, right now passing 0
-        guard let buf = cmark_markdown_to_html($0, Int(strlen($0)), 0) else {
-        	throw MarkdownError.conversionFailed
-        }
-        buffer = String(cString: buf)
-        free(buf)
-    }
-    guard let output = buffer else { 
-        throw MarkdownError.conversionFailed
-    }
-    return output
+	try str.withCString {
+		guard let buf = cmark_markdown_to_html($0, Int(strlen($0)), options.rawValue) else {
+			throw MarkdownError.conversionFailed
+		}
+		buffer = String(cString: buf)
+		free(buf)
+	}
+	guard let output = buffer else {
+		throw MarkdownError.conversionFailed
+	}
+	return output
 }
 


### PR DESCRIPTION
I saw that there was a TODO for implementing cmark options so I took the liberty of adding them myself with a MarkdownOptions struct. I changed the method signature `markdownToHTML(_:)` to `markdownToHTML(_:options:)` and added a default options arguement of `[]` . That way, any packages using the old API can continue to function as usual. Verified that it still passes the lone test (should there be more?).

I also went ahead and removed the Warning section from the README. The bug it mentions has already been resolved ([see here](https://bugs.swift.org/browse/SR-2526)) so it'll just be confusing to new users if we leave it there.